### PR TITLE
Feature: Model selection in init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Options:
 
 Interactive setup wizard. Creates `.onpush/config.yml`.
 
+- Select AI provider: **Anthropic** or **GitHub Copilot**
+- Select AI model (provider-specific presets or custom model name)
 - Select mode: **Current Repo** or **Remote Repo(s)**
 - Configure project name, output directory, document types
 - Create custom document types with guided prompts
@@ -215,7 +217,7 @@ output:
 
 generation:
   provider: "anthropic"  # or "copilot"
-  model: "claude-sonnet-4-6"
+  model: "claude-opus-4-6"
   cost_limit: null
   timeout: 3600
   parallel: 10

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -5,7 +5,6 @@ import { stringify as yamlStringify } from "yaml";
 import { runInitWizard, type InitWizardResult, type ExistingConfig } from "../ui/prompts.js";
 import { CancelError } from "../../core/errors.js";
 import { DEFAULT_DOCUMENT_TYPES } from "../../core/document-types.js";
-import { DEFAULT_MODELS } from "../../generation/providers/types.js";
 import { loadConfig } from "../../core/config.js";
 
 export function registerInitCommand(program: Command): void {
@@ -37,6 +36,7 @@ export function registerInitCommand(program: Command): void {
 
         existing = {
           provider: config.generation.provider,
+          model: config.generation.model,
           mode: config.mode,
           projectName: config.project.name,
           projectDescription: config.project.description,
@@ -91,7 +91,7 @@ async function writeConfig(result: InitWizardResult): Promise<void> {
     },
     generation: {
       provider: result.provider,
-      model: DEFAULT_MODELS[result.provider],
+      model: result.model,
       cost_limit: null,
       timeout: result.timeout,
       parallel: result.parallel,

--- a/src/cli/ui/prompts.ts
+++ b/src/cli/ui/prompts.ts
@@ -5,6 +5,7 @@ import { CancelError } from "../../core/errors.js";
 
 export interface InitWizardResult {
   provider: "anthropic" | "copilot";
+  model: string;
   mode: "current" | "remote";
   projectName: string;
   projectDescription?: string;
@@ -48,6 +49,7 @@ const SECURITY_EXCLUDES = [
  */
 export interface ExistingConfig {
   provider?: "anthropic" | "copilot";
+  model?: string;
   mode?: "current" | "remote";
   projectName?: string;
   projectDescription?: string;
@@ -80,6 +82,48 @@ export async function runInitWizard(existing?: ExistingConfig): Promise<InitWiza
   if (p.isCancel(provider)) {
     p.cancel("Setup cancelled.");
     throw new CancelError();
+  }
+
+  // Model selection — options depend on provider
+  const CUSTOM_MODEL_VALUE = "__custom__";
+  const modelOptions =
+    provider === "anthropic"
+      ? [
+          { value: "claude-opus-4-6", label: "Opus 4.6 (Default)" },
+          { value: "claude-sonnet-4-6", label: "Sonnet 4.6" },
+          { value: CUSTOM_MODEL_VALUE, label: "Custom model…" },
+        ]
+      : [
+          { value: "claude-opus-4-6", label: "Opus 4.6 (Default)" },
+          { value: "gpt-5.3-codex", label: "GPT-5.3-Codex" },
+          { value: CUSTOM_MODEL_VALUE, label: "Custom model…" },
+        ];
+
+  let model = (await p.select({
+    message: "Model",
+    initialValue: existing?.model ?? "claude-opus-4-6",
+    options: modelOptions,
+  })) as string;
+
+  if (p.isCancel(model)) {
+    p.cancel("Setup cancelled.");
+    throw new CancelError();
+  }
+
+  if (model === CUSTOM_MODEL_VALUE) {
+    const customModel = (await p.text({
+      message: "Enter model name",
+      validate: (value) => {
+        if (!value?.trim()) return "Model name is required";
+      },
+    })) as string;
+
+    if (p.isCancel(customModel)) {
+      p.cancel("Setup cancelled.");
+      throw new CancelError();
+    }
+
+    model = customModel;
   }
 
   const mode = (await p.select({
@@ -260,6 +304,7 @@ export async function runInitWizard(existing?: ExistingConfig): Promise<InitWiza
 
   return {
     provider,
+    model,
     mode,
     projectName,
     projectDescription: projectDescription || undefined,

--- a/src/generation/providers/__tests__/types.test.ts
+++ b/src/generation/providers/__tests__/types.test.ts
@@ -1,12 +1,12 @@
 import { DEFAULT_MODELS } from "../types.js";
 
 describe("DEFAULT_MODELS", () => {
-  it("has anthropic model set to claude-sonnet-4-6", () => {
-    expect(DEFAULT_MODELS.anthropic).toBe("claude-sonnet-4-6");
+  it("has anthropic model set to claude-opus-4-6", () => {
+    expect(DEFAULT_MODELS.anthropic).toBe("claude-opus-4-6");
   });
 
-  it("has copilot model set to gpt-4.1", () => {
-    expect(DEFAULT_MODELS.copilot).toBe("gpt-4.1");
+  it("has copilot model set to claude-opus-4-6", () => {
+    expect(DEFAULT_MODELS.copilot).toBe("claude-opus-4-6");
   });
 
   it("has exactly 2 entries", () => {

--- a/src/generation/providers/types.ts
+++ b/src/generation/providers/types.ts
@@ -21,6 +21,6 @@ export interface DocAgentProvider {
 }
 
 export const DEFAULT_MODELS: Record<ProviderName, string> = {
-  anthropic: "claude-sonnet-4-6",
-  copilot: "gpt-4.1",
+  anthropic: "claude-opus-4-6",
+  copilot: "claude-opus-4-6",
 };


### PR DESCRIPTION
Added model selection to init command, set default model for both providers to Opus 4.6 and added ability to provide custom model names.